### PR TITLE
Add support for functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This SDK makes it simple to:
 - [stream chat responses](#streaming-conversations)
 - [cancel chat responses](#cancelling-responses)
 - [override the API endpoint](#overriding-api)
+- [utilize chat functions](#utilizing-functions)
 
 ## Usage
 
@@ -148,6 +149,60 @@ const chat = createChat({
   apiUrl: 'https://ray.run/api/completions'
   model: "gpt-3.5-turbo",
 });
+```
+
+### Utilizing Functions
+
+The OpenAI chat models can embed functions directly into the system prompt in a special format such that the model has better understanding of them and can know when to use them. ([see more documentation](https://platform.openai.com/docs/guides/gpt/function-calling))
+
+To use this feature you must define a prototype and provide a description for the function when you create the chat. The model will decide when it wants to use the function. It is up to you implement the logic around checking if the model wants to use them.
+
+```ts
+import { createChat } from "./createChat";
+
+const chat = createChat({
+  apiKey: OPENAI_API_KEY,
+  model: "gpt-3.5-turbo-0613",
+  functions: [
+    {
+      name: "get_current_weather",
+      description: "Get the current weather in a given location",
+      parameters: {
+        type: "object",
+        properties: {
+          location: {
+            type: "string",
+            description: "The city and state, e.g. San Francisco, CA",
+          },
+          unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+        },
+        required: ["location"],
+      },
+    },
+  ],
+  functionCall: "auto",
+});
+
+const responseWantingFunction = await chat.sendMessage("What is the weather in Albuquerque?");
+
+if (responseWantingFunction.function_call?.name === "get_current_weather") {
+  const response = await chat.sendMessage(
+    JSON.stringify({
+      location: "Albuquerque",
+      temperature: "72",
+      unit: "fahrenheit",
+      forecast: ["sunny", "windy"],
+    }),
+    undefined,
+    "get_current_weather"
+  );
+
+  console.log(response.content);
+  // "The weather in Albuquerque is 72 degrees fahrenheit, sunny with a light breeze."
+} else {
+  // handle responses like normal otherwise
+}
+
 ```
 
 ## My other projects

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const chat = createChat({
   // model: 'gpt-4',
 });
 
-await chat.sentMessage("Ping");
+await chat.sendMessage("Ping");
 
 // {
 //   response: { role: 'assistant', content: 'Pong', finishReason: 'stop' }
@@ -75,7 +75,7 @@ const chat = createChat({
   model: "gpt-3.5-turbo",
 });
 
-await chat.sentMessage("pick a random number");
+await chat.sendMessage("pick a random number");
 
 // Gets all messages sent and received.
 // This can be used to resume chat at a later time.
@@ -93,7 +93,7 @@ for (const message of messages) {
   chat.addMessage(message);
 }
 
-await chat.sentMessage("what random number did you pick?");
+await chat.sendMessage("what random number did you pick?");
 ```
 
 ### Streaming conversations
@@ -104,7 +104,7 @@ const chat = createChat({
   model: "gpt-3.5-turbo",
 });
 
-await chat.sentMessage("continue the sequence: a b c", (message) => {
+await chat.sendMessage("continue the sequence: a b c", (message) => {
   console.log(message);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ import { createChat } from "completions";
  *    We generally recommend altering this or temperature but not both.
  * @property user - A unique identifier representing your end-user, which can help OpenAI
  *    to monitor and detect abuse.
+ * @property functionCall - Whether or not the model is allowed to call a function.
+ * @property functions - Specifications for functions which the model can call.
  */
 const chat = createChat({
   apiKey: process.env.OPENAI_API_KEY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^16.1.4",
         "ts-custom-error": "^3.3.1",
         "zod": "^3.21.4"
       },
@@ -1462,6 +1463,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/duplexer2": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "dotenv": "^16.1.4",
     "ts-custom-error": "^3.3.1",
     "zod": "^3.21.4"
   },
@@ -17,7 +18,8 @@
     "openai",
     "chat",
     "completions",
-    "stream"
+    "stream",
+    "functions"
   ],
   "release": {
     "branches": [
@@ -42,9 +44,9 @@
     "typescript": "^5.1.3"
   },
   "scripts": {
-    "lint": "prettier --check .",
+    "lint": "prettier --check ./src",
     "build": "tsc --noEmit false",
-    "test": "tsx --test src/createChat.test.ts",
+    "test": "tsx --test src/createChat.test.ts && tsx --test src/function.test.ts",
     "semantic-release": "semantic-release"
   },
   "version": "0.0.0-development"

--- a/src/createChat.test.ts
+++ b/src/createChat.test.ts
@@ -2,6 +2,10 @@ import { strict as assert } from "node:assert";
 import { test, mock } from "node:test";
 import { createChat } from "./createChat";
 import { Message } from "./createCompletions";
+import dotenv from "dotenv";
+import { join } from "path";
+
+dotenv.config({ path: join(__dirname, "..", ".env") });
 
 const { OPENAI_API_KEY } = process.env;
 

--- a/src/createChat.ts
+++ b/src/createChat.ts
@@ -24,8 +24,6 @@ export const createChat = (
 
     messages.push(message);
 
-    console.log("messages", messages);
-
     const result = await retry(() => {
       return createCompletions({
         messages,

--- a/src/createChat.ts
+++ b/src/createChat.ts
@@ -13,14 +13,18 @@ export const createChat = (
 
   const sendMessage = async (
     prompt: string,
-    onMessage?: CompletionsOptions["onMessage"]
+    onMessage?: CompletionsOptions["onMessage"],
+    functionName?: string
   ) => {
     const message: Message = {
       content: prompt,
-      role: "user",
+      role: !!functionName ? "function" : "user",
+      name: functionName,
     };
 
     messages.push(message);
+
+    console.log("messages", messages);
 
     const result = await retry(() => {
       return createCompletions({

--- a/src/createCompletions.ts
+++ b/src/createCompletions.ts
@@ -79,6 +79,8 @@ const ResponseChunkZodSchema = z
  *    We generally recommend altering this or temperature but not both.
  * @property user - A unique identifier representing your end-user, which can help OpenAI
  *    to monitor and detect abuse.
+ * @property functionCall - Whether or not the model is allowed to call a function.
+ * @property functions - Specifications for functions which the model can call.
  */
 const CompletionsOptionsZodSchema = z
   .object({
@@ -105,7 +107,7 @@ const CompletionsOptionsZodSchema = z
     logitBias: z.record(z.number()).optional(),
     maxTokens: z.number().optional(),
     user: z.string().optional(),
-    function_call: z.enum(["auto", "none"]).optional(),
+    functionCall: z.enum(["auto", "none"]).optional(),
     functions: z
       .array(
         z.object({
@@ -168,7 +170,7 @@ export const createCompletions = async (
         logit_bias: options.logitBias,
         max_tokens: options.maxTokens,
         user: options.user,
-        function_call: options.function_call,
+        function_call: options.functionCall,
         functions: options.functions,
       }),
       method: "POST",

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -12,10 +12,6 @@ if (!OPENAI_API_KEY) {
   throw new Error("OPENAI_API_KEY must be set");
 }
 
-if (!OPENAI_API_KEY) {
-  throw new Error("OPENAI_API_KEY must be set");
-}
-
 test("Adds a function to the chat model and calls it, then does one more message for completeness", async () => {
   const chat = createChat({
     apiKey: OPENAI_API_KEY,
@@ -40,11 +36,16 @@ test("Adds a function to the chat model and calls it, then does one more message
     functionCall: "auto",
   });
 
-  await chat.sendMessage("What is the weather in Albuquerque?");
+  const response = await chat.sendMessage(
+    "What is the weather in Albuquerque?"
+  );
 
-  // console.log(response.content);
+  assert(
+    response.role === "assistant" &&
+      response.function_call?.name === "get_current_weather"
+  );
 
-  await chat.sendMessage(
+  const response2 = await chat.sendMessage(
     JSON.stringify({
       location: "Albuquerque",
       temperature: "72",
@@ -55,7 +56,7 @@ test("Adds a function to the chat model and calls it, then does one more message
     "get_current_weather"
   );
 
-  // console.log(response2.content);
+  assert(response2.content?.length > 0 && response2.role === "assistant");
 
   const response3 = await chat.sendMessage(
     "Is this too hot to have a pet polar bear?"

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -1,0 +1,66 @@
+import * as dotenv from "dotenv";
+import { join } from "path";
+import { createChat } from "./createChat";
+import { strict as assert } from "node:assert";
+
+dotenv.config({ path: join(__dirname, "..", ".env") });
+
+const { OPENAI_API_KEY } = process.env;
+
+if (!OPENAI_API_KEY) {
+  throw new Error("OPENAI_API_KEY must be set");
+}
+
+if (!OPENAI_API_KEY) {
+  throw new Error("OPENAI_API_KEY must be set");
+}
+
+(async () => {
+  const chat = createChat({
+    apiKey: OPENAI_API_KEY,
+    model: "gpt-3.5-turbo-0613",
+    functions: [
+      {
+        name: "get_current_weather",
+        description: "Get the current weather in a given location",
+        parameters: {
+          type: "object",
+          properties: {
+            location: {
+              type: "string",
+              description: "The city and state, e.g. San Francisco, CA",
+            },
+            unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+          },
+          required: ["location"],
+        },
+      },
+    ],
+    function_call: "auto",
+  });
+
+  await chat.sendMessage("What is the weather in Albuquerque?");
+
+  // console.log(response.content);
+
+  await chat.sendMessage(
+    JSON.stringify({
+      location: "Albuquerque",
+      temperature: "72",
+      unit: "fahrenheit",
+      forecast: ["sunny", "windy"],
+    }),
+    undefined,
+    "get_current_weather"
+  );
+
+  // console.log(response2.content);
+
+  const response3 = await chat.sendMessage(
+    "Is this too hot to have a pet polar bear?"
+  );
+
+  // console.log(response3.content);
+
+  assert(/yes/i.test(response3.content));
+})();

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 import { join } from "path";
 import { createChat } from "./createChat";
 import { strict as assert } from "node:assert";
+import { test } from "node:test";
 
 dotenv.config({ path: join(__dirname, "..", ".env") });
 
@@ -15,7 +16,7 @@ if (!OPENAI_API_KEY) {
   throw new Error("OPENAI_API_KEY must be set");
 }
 
-(async () => {
+test("Adds a function to the chat model and calls it, then does one more message for completeness", async () => {
   const chat = createChat({
     apiKey: OPENAI_API_KEY,
     model: "gpt-3.5-turbo-0613",
@@ -36,7 +37,7 @@ if (!OPENAI_API_KEY) {
         },
       },
     ],
-    function_call: "auto",
+    functionCall: "auto",
   });
 
   await chat.sendMessage("What is the weather in Albuquerque?");
@@ -63,4 +64,4 @@ if (!OPENAI_API_KEY) {
   // console.log(response3.content);
 
   assert(/yes/i.test(response3.content));
-})();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "lib": ["DOM"],
     "outDir": "dist",


### PR DESCRIPTION
Add support for functions in chat endpoint.
See: https://platform.openai.com/docs/guides/gpt/function-calling

I marked this draft, because in the zod schema for specifying function parameters there is a `z.any()` which is not ideal. I need to find the official documentation for what is allowed here to understand exactly what this schema should be. Additionally while I did add a test for it I did nothing in regards of documentation in the readme or anything.