### PR TITLE
Allow overriding arbitrary options for sendMessage

### DIFF
--- a/src/createChat.ts
+++ b/src/createChat.ts
@@ -7,14 +7,15 @@ import { retry } from "./retry";
 import { omit } from "./omit";
 
 export const createChat = (
-  options: Omit<Omit<Omit<CompletionsOptions, "messages">, "n">, "onMessage">
+  options: Omit<Omit<CompletionsOptions, "n">, "onMessage">
 ) => {
-  const messages: Message[] = [];
+  const messages: Message[] = options.messages ?? [];
 
   const sendMessage = async (
     prompt: string,
     onMessage?: CompletionsOptions["onMessage"],
-    functionName?: string
+    functionName?: string,
+    optionsOverrides?: Partial<Omit<typeof options, "messages">>
   ) => {
     const message: Message = {
       content: prompt,
@@ -29,6 +30,7 @@ export const createChat = (
         messages,
         onMessage,
         ...options,
+        ...optionsOverrides,
       });
     });
 
@@ -63,3 +65,5 @@ export const createChat = (
     sendMessage,
   };
 };
+
+export type Chat = ReturnType<typeof createChat>;

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -12,7 +12,7 @@ if (!OPENAI_API_KEY) {
   throw new Error("OPENAI_API_KEY must be set");
 }
 
-test("Adds a function to the chat model and calls it, then does one more message for completeness", async () => {
+test("Tests function calling and forcing user facing response", async () => {
   const chat = createChat({
     apiKey: OPENAI_API_KEY,
     model: "gpt-3.5-turbo-0613",
@@ -62,7 +62,21 @@ test("Adds a function to the chat model and calls it, then does one more message
     "Is this too hot to have a pet polar bear?"
   );
 
-  // console.log(response3.content);
-
   assert(/yes/i.test(response3.content));
+
+  // Test option overriding to force the user facing response
+  const response4 = await chat.sendMessage(
+    "What is the weather in Chicago?",
+    undefined,
+    undefined,
+    {
+      functionCall: "none",
+    }
+  );
+
+  assert(
+    response4.role === "assistant" &&
+      !response4.function_call &&
+      response4.content?.length > 0
+  );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { createChat } from "./createChat";
-export { type Message } from "./createCompletions";
+export { createChat, type Chat } from "./createChat";
+export { type Message, type CompletionsOptions } from "./createCompletions";
 export { CancelledCompletionError, UnrecoverableRemoteError } from "./errors";


### PR DESCRIPTION
- I realized that you need to be able to override individual options for a single `sendMessage` call
- Being able to construct the chat with an array of messages mimics how in the openai official sdk `createChatCompletion` takes messages and saves having to add them all in a loop later
- Added a named type for the returned type of `createChat`

Sorry to bother you with another pr in such a short time frame.