### PR TITLE
add chat cancel method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ try {
 }
 ```
 
+Alternatively the `Chat` instance has a method `cancelStream` which which allows equivalent functionality to the above without having to use the `cancel` property of the `onUpdate` callback. (This is useful if you want to have a way to cancel the stream from something removed for the details of handling the streams.)
+
+```ts
+import { createChat, CancelledCompletionError } from "completions";
+
+const chat = createChat({
+  apiKey: OPENAI_API_KEY,
+  model: "gpt-3.5-turbo",
+});
+
+try {
+  const responsePromise = chat.sendMessage("continue sequence: a b c");
+  // in practice this would be linked to something external
+  chat.cancelStream();
+  await responsePromise;
+} catch (error) {
+  if (error instanceof CancelledCompletion) {
+    console.log("cancelled");
+  }
+
+  throw error;
+}
+```
+
 ### Overriding API
 
 If you want to use `completions` library against another API endpoint that is compatible with the official API, you can do so by passing `apiUrl` parameter:

--- a/src/createChat.test.ts
+++ b/src/createChat.test.ts
@@ -103,6 +103,14 @@ test("cancel response", async () => {
       },
     })
   );
+
+  const chatPromise = chat.sendMessage("continue sequence: a b c");
+  chat.cancelStream();
+  await assert.rejects(chatPromise);
+
+  // make sure that the chat still functions after cancelling
+  const response = await chat.sendMessage("continue sequence: a b c");
+  assert(response.content);
 });
 
 test("calls user defined function", async () => {

--- a/src/createCompletions.ts
+++ b/src/createCompletions.ts
@@ -169,7 +169,8 @@ export type CompletionResponse = {
 };
 
 export const createCompletions = async (
-  options: CompletionsOptions
+  options: CompletionsOptions,
+  cancel: { cancelled: boolean }
 ): Promise<CompletionResponse> => {
   CompletionsOptionsZodSchema.parse(options);
 
@@ -207,8 +208,6 @@ export const createCompletions = async (
   const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
 
   const choices: Choice[] = [];
-
-  let cancelled = false;
 
   while (true) {
     const { value, done } = await reader.read();
@@ -260,7 +259,7 @@ export const createCompletions = async (
 
       options.onUpdate?.({
         cancel: () => {
-          cancelled = true;
+          cancel.cancelled = true;
 
           reader.cancel();
         },
@@ -302,7 +301,7 @@ export const createCompletions = async (
     }
   }
 
-  if (cancelled) {
+  if (cancel.cancelled) {
     throw new CancelledCompletionError(choices);
   }
 


### PR DESCRIPTION
This addresses https://github.com/lucgagan/completions/issues/8 by adding a `cancelStream` method to the chat object.